### PR TITLE
fix: ensure extras is an array

### DIFF
--- a/lib/jsdoc/src/parser.js
+++ b/lib/jsdoc/src/parser.js
@@ -219,7 +219,10 @@ Parser.prototype.parseExtra = function(filename, info) {
     var name = info.name.replace('exports.', '');
 
     this._extras[filename] = this._extras[filename] || {};
-    this._extras[filename][name] = this._extras[filename][name] || [];
+    const extrasArr = this._extras[filename][name] || [];
+    this._extras[filename][name] = extrasArr && !Array.isArray(extrasArr)
+        ? [extrasArr]
+        : extrasArr
 
     var ts = removeTSParenthesizedType(info.extra);
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | no
| License          | Apache-2.0

## Context

* I was getting an error when building my project. These changes fixed the issue and allowed it to build. No idea what's actually happening here, but figured I'd submit a PR anyways.

![image](https://github.com/daybrush/jsdoc/assets/8345382/d6f50931-df96-4199-87f8-c8674f2afd67)


## Fix

* Ensure `this._extras[filename][name]` is an array
* What it looks like when printed out, without these changes

![image](https://github.com/daybrush/jsdoc/assets/8345382/e274ff4b-9821-4f66-9f5e-19315f777544)



